### PR TITLE
Fix README source code path

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Pre-reqs: `docker-machine` and `make`
 * Build and install the driver:
 
 ```
-$ cd $GOPATH/github.com/packethost/docker-machine-driver-packet
+$ cd $GOPATH/src/github.com/packethost/docker-machine-driver-packet
 $ make 
 $ sudo make install
 ```


### PR DESCRIPTION
Go source code lives under `$GOPATH/src/github.com/packethost/docker-machine-driver-packet`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/docker-machine-driver-packet/15)
<!-- Reviewable:end -->
