### PR TITLE
Lock in current dependencies for the driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.11.0
 
 ENV REPO github.com/packethost/docker-machine-driver-packet
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean:
 	rm -r bin/docker-machine*
 
 compile:
-	GOGC=off CGOENABLED=0 go build -ldflags "-s" -o bin/$(current_dir)$(BIN_SUFFIX)/$(current_dir) bin/main.go
+	GO111MODULE=on GOGC=off CGOENABLED=0 go build -ldflags "-s" -o bin/$(current_dir)$(BIN_SUFFIX)/$(current_dir) ./bin/...
 
 pack: cross
 	find ./bin -mindepth 1 -type d -exec zip -r -j {}.zip {} \;

--- a/README.md
+++ b/README.md
@@ -57,14 +57,15 @@ At this point you can now `docker-machine env sloth` and then start using your D
 
 Pre-reqs: `docker-machine` and `make`
 
-* Install the Golang SDK [https://golang.org/dl/](https://golang.org/dl/)
+* Install the Golang SDK [https://golang.org/dl/](https://golang.org/dl/) (at least 1.11 required for [modules](https://github.com/golang/go/wiki/Modules) support
 
-* Download the source-code with `go get -u github.com/packethost/docker-machine-driver-packet`
+* Download the source-code with
+  `git clone http://github.com/packethost/docker-machine-driver-packet.git`
 
 * Build and install the driver:
 
 ```
-$ cd $GOPATH/src/github.com/packethost/docker-machine-driver-packet
+$ cd docker-machine-driver-packet
 $ make 
 $ sudo make install
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/packethost/docker-machine-driver-packet
+
+require (
+	github.com/docker/docker v1.13.1 // indirect
+	github.com/docker/machine v0.16.0
+	github.com/packethost/packngo v0.1.1-0.20180928144907-4099eefca497
+	golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869 // indirect
+	golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
+github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/machine v0.16.0 h1:nLI3xyw6MD6qgw1e3Cv/oyW6qTpioU+SSDxoQQ5Mw+Q=
+github.com/docker/machine v0.16.0/go.mod h1:I8mPNDeK1uH+JTcUU7X0ZW8KiYz0jyAgNaeSJ1rCfDI=
+github.com/packethost/packngo v0.1.1-0.20180928144907-4099eefca497 h1:fBvzGYp3BxdrV4UayvaqYzuL8hEDNKQ/rbdEI7OxUJY=
+github.com/packethost/packngo v0.1.1-0.20180928144907-4099eefca497/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
+golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869 h1:kkXA53yGe04D0adEYJwEVQjeBppL01Exg+fnMjfUraU=
+golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8 h1:YoY1wS6JYVRpIfFngRf2HHo9R9dAne3xbkGOQ5rJXjU=
+golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
The packngo API has changed, resulting in build failures in fresh source
checkouts. Makes use of the opt-in modules[1] in Go 1.11 to lock
dependencies to the latest, except packngo, which is locked down at
commit 4099eefca4977c9a4909da715fa11055cdcf43c6, which is prior to the
Facility type change.

[1] https://github.com/golang/go/wiki/Modules

Fixes #32.