### PR TITLE
Fix link to API keys in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This creates the following:
 * in the EWR region (NJ)
 * with Ubuntu 16.04
 * in project $PROJECT
-* Using $API_KEY - [get yours from the Portal](https://app.packet.net/portal#/api-keys)
+* Using $API_KEY - [get yours from the Portal](https://app.packet.net/users/me/api-keys)
 
 ```
 $ docker-machine create sloth \


### PR DESCRIPTION
The previous link leads to a 404 page. This changes it to point to the user's API keys page.