### PR TITLE
remove terraform-provider-packet link from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,6 @@
 ### Code of Conduct
 Available via [https://github.com/packethost/docker-machine-driver-packet/blob/master/.github/CODE_OF_CONDUCT.md](https://github.com/packethost/docker-machine-driver-packet/blob/master/.github/CODE_OF_CONDUCT.md)
 
-### Environment Details
-[https://github.com/packethost/terraform-provider-packet/blob/master/Makefile](https://github.com/packethost/docker-machine-driver-packet/blob/master/Makefile)
-
 ### How to Submit Change Requests
 Please submit change requests and / or features via [Issues](https://github.com/packethost/docker-machine-driver-packet/issues). There's no guarantee it'll be changed, but you never know until you try. We'll try to add comments as soon as possible, though.
 


### PR DESCRIPTION
Even though this linked to the local Makefile, it's not clear how the Makefile represented the "Environment" in a context that makes sense for contributions. I think the was copy/pasted from another project where the Environment or Makefile was more important to the contribution notes.