### PR TITLE
chore: delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @displague


### PR DESCRIPTION
I'm not an active CODEOWNER, I'm a former contributor.